### PR TITLE
HOLIDAYREQ-20 + pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.xwiki.commons</groupId>
     <artifactId>xwiki-commons-pom</artifactId>
-    <version>4.5.4</version>
+    <version>4.3</version>
   </parent>
   <groupId>org.xwiki.contrib</groupId>
   <artifactId>xwiki-application-holidayrequest</artifactId>

--- a/src/main/resources/HolidayRequest/Summary.xml
+++ b/src/main/resources/HolidayRequest/Summary.xml
@@ -65,7 +65,14 @@ Request.eachWithIndex()
   if(obj!=null &amp;&amp; obj.get('status')==accept)
   {
     numberDays = obj.get('numberDays')
-    numberDays = Float.parseFloat(numberDays)
+    if(numberDays != null &amp;&amp; numberDays.size() &gt; 0)
+    {
+       numberDays = Float.parseFloat(numberDays)
+    }
+    else
+    {
+       numberDays = 0
+    }
     employee = obj.get('employee')
     if(mapUsersDays.containsKey(employee))
     {


### PR DESCRIPTION
HOLIDAYREQ-20: Overview doesn't work when 'numberDays' property is empty in a request

[Misc] Fix 'Version' in pom
